### PR TITLE
`logOps` setting in hardhat.config.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@fhenixprotocol/cofhe-contracts": "0.0.13",
-    "@fhenixprotocol/cofhe-mock-contracts": "^0.0.2",
+    "@fhenixprotocol/cofhe-mock-contracts": "^0.0.3",
     "@nomicfoundation/hardhat-ethers": "^3.0.0",
     "@openzeppelin/contracts": "^5.0.0",
     "@openzeppelin/contracts-upgradeable": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "devDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
+    "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
     "@types/chai": "^4.1.7",
     "@types/eslint": "^8",
     "@types/fs-extra": "^11.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 0.0.13
         version: 0.0.13
       '@fhenixprotocol/cofhe-mock-contracts':
-        specifier: ^0.0.2
-        version: 0.0.2(@fhenixprotocol/cofhe-contracts@0.0.13)(@openzeppelin/contracts-upgradeable@5.2.0(@openzeppelin/contracts@5.2.0))(@openzeppelin/contracts@5.2.0)
+        specifier: ^0.0.3
+        version: 0.0.3(@fhenixprotocol/cofhe-contracts@0.0.13)(@openzeppelin/contracts-upgradeable@5.2.0(@openzeppelin/contracts@5.2.0))(@openzeppelin/contracts@5.2.0)
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.0
         version: 3.0.8(ethers@6.10.0)(hardhat@2.22.19(ts-node@8.10.2(typescript@5.8.2))(typescript@5.8.2))
@@ -178,8 +178,8 @@ packages:
   '@fhenixprotocol/cofhe-contracts@0.0.13':
     resolution: {integrity: sha512-+lHo5v52fR7QfQj2ottDw4F/AqZg6obPBRqvK576SJatX3o4aH6ZSt2kxNb5kT8Ckthjw6FoNmLdUVCDpP400w==}
 
-  '@fhenixprotocol/cofhe-mock-contracts@0.0.2':
-    resolution: {integrity: sha512-SmZlE4PDTyuiSfajDRIAmqgf1d5GlP+dnPt8m69exy5gPZp/bYCYh8GE0oeWUR26MSZGNNNp3wx/V77PF13kTA==}
+  '@fhenixprotocol/cofhe-mock-contracts@0.0.3':
+    resolution: {integrity: sha512-81tGSbupe+7aprpc97lAOJHbr5YIcxHAEBX05wc085Sz1/Oxlohii8jsV7yJnzx2lVRMSqyD453jjfkcKsJ6cA==}
     peerDependencies:
       '@fhenixprotocol/cofhe-contracts': 0.0.13
       '@openzeppelin/contracts': ^5.0.0
@@ -1831,7 +1831,7 @@ snapshots:
     dependencies:
       '@openzeppelin/contracts': 5.2.0
 
-  '@fhenixprotocol/cofhe-mock-contracts@0.0.2(@fhenixprotocol/cofhe-contracts@0.0.13)(@openzeppelin/contracts-upgradeable@5.2.0(@openzeppelin/contracts@5.2.0))(@openzeppelin/contracts@5.2.0)':
+  '@fhenixprotocol/cofhe-mock-contracts@0.0.3(@fhenixprotocol/cofhe-contracts@0.0.13)(@openzeppelin/contracts-upgradeable@5.2.0(@openzeppelin/contracts@5.2.0))(@openzeppelin/contracts@5.2.0)':
     dependencies:
       '@fhenixprotocol/cofhe-contracts': 0.0.13
       '@openzeppelin/contracts': 5.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
         specifier: ^3.3.2
         version: 3.3.3
     devDependencies:
+      '@nomicfoundation/hardhat-chai-matchers':
+        specifier: ^2.0.0
+        version: 2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.10.0)(hardhat@2.22.19(ts-node@8.10.2(typescript@5.8.2))(typescript@5.8.2)))(chai@4.3.10)(ethers@6.10.0)(hardhat@2.22.19(ts-node@8.10.2(typescript@5.8.2))(typescript@5.8.2))
       '@types/chai':
         specifier: ^4.1.7
         version: 4.3.11
@@ -282,6 +285,14 @@ packages:
       c-kzg:
         optional: true
 
+  '@nomicfoundation/hardhat-chai-matchers@2.0.8':
+    resolution: {integrity: sha512-Z5PiCXH4xhNLASROlSUOADfhfpfhYO6D7Hn9xp8PddmHey0jq704cr6kfU8TRrQ4PUZbpfsZadPj+pCfZdjPIg==}
+    peerDependencies:
+      '@nomicfoundation/hardhat-ethers': ^3.0.0
+      chai: ^4.2.0
+      ethers: ^6.1.0
+      hardhat: ^2.9.4
+
   '@nomicfoundation/hardhat-ethers@3.0.8':
     resolution: {integrity: sha512-zhOZ4hdRORls31DTOqg+GmEZM0ujly8GGIuRY7t7szEk2zW/arY1qDug/py8AEktT00v5K+b6RvbVog+va51IA==}
     peerDependencies:
@@ -402,6 +413,9 @@ packages:
 
   '@types/bn.js@5.1.5':
     resolution: {integrity: sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==}
+
+  '@types/chai-as-promised@7.1.8':
+    resolution: {integrity: sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==}
 
   '@types/chai@4.3.11':
     resolution: {integrity: sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==}
@@ -627,6 +641,11 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  chai-as-promised@7.1.2:
+    resolution: {integrity: sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==}
+    peerDependencies:
+      chai: '>= 2.1.2 < 6'
 
   chai@4.3.10:
     resolution: {integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==}
@@ -1233,6 +1252,9 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ordinal@1.0.3:
+    resolution: {integrity: sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==}
 
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
@@ -1901,6 +1923,17 @@ snapshots:
       '@nomicfoundation/ethereumjs-rlp': 5.0.4
       ethereum-cryptography: 0.1.3
 
+  '@nomicfoundation/hardhat-chai-matchers@2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.10.0)(hardhat@2.22.19(ts-node@8.10.2(typescript@5.8.2))(typescript@5.8.2)))(chai@4.3.10)(ethers@6.10.0)(hardhat@2.22.19(ts-node@8.10.2(typescript@5.8.2))(typescript@5.8.2))':
+    dependencies:
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.10.0)(hardhat@2.22.19(ts-node@8.10.2(typescript@5.8.2))(typescript@5.8.2))
+      '@types/chai-as-promised': 7.1.8
+      chai: 4.3.10
+      chai-as-promised: 7.1.2(chai@4.3.10)
+      deep-eql: 4.1.3
+      ethers: 6.10.0
+      hardhat: 2.22.19(ts-node@8.10.2(typescript@5.8.2))(typescript@5.8.2)
+      ordinal: 1.0.3
+
   '@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.10.0)(hardhat@2.22.19(ts-node@8.10.2(typescript@5.8.2))(typescript@5.8.2))':
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
@@ -2028,6 +2061,10 @@ snapshots:
   '@types/bn.js@5.1.5':
     dependencies:
       '@types/node': 16.18.126
+
+  '@types/chai-as-promised@7.1.8':
+    dependencies:
+      '@types/chai': 4.3.11
 
   '@types/chai@4.3.11': {}
 
@@ -2287,6 +2324,11 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase@6.3.0: {}
+
+  chai-as-promised@7.1.2(chai@4.3.10):
+    dependencies:
+      chai: 4.3.10
+      check-error: 1.0.3
 
   chai@4.3.10:
     dependencies:
@@ -3014,6 +3056,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ordinal@1.0.3: {}
 
   os-tmpdir@1.0.2: {}
 

--- a/src/deploy-mocks.ts
+++ b/src/deploy-mocks.ts
@@ -168,7 +168,13 @@ const setTaskManagerLogOps = async (taskManager: Contract, logOps: boolean) => {
 
 export const deployMocks = async (
   hre: HardhatRuntimeEnvironment,
-  deployTestBed = false,
+  options: {
+    deployTestBed?: boolean;
+    logOps?: boolean;
+  } = {
+    deployTestBed: true,
+    logOps: true,
+  },
 ) => {
   // Check if network is Hardhat, if not log skip message and return
   const isHardhat = await checkNetworkAndSkip(hre);
@@ -188,8 +194,7 @@ export const deployMocks = async (
   const taskManager = await deployMockTaskManager(hre);
   logDeployment("MockTaskManager", await taskManager.getAddress());
 
-  const logOps = true;
-  if (logOps) {
+  if (options.logOps) {
     await setTaskManagerLogOps(taskManager, true);
     logSuccess("TaskManager logOps set", 2);
   }
@@ -206,7 +211,7 @@ export const deployMocks = async (
   const queryDecrypter = await deployMockQueryDecrypter(hre, acl);
   logDeployment("MockQueryDecrypter", await queryDecrypter.getAddress());
 
-  if (deployTestBed) {
+  if (options.deployTestBed) {
     logSuccess("TestBed deployment enabled", 2);
     const testBed = await deployTestBedContract(hre);
     logDeployment("TestBed", await testBed.getAddress());

--- a/test/deploy-mocks.test.ts
+++ b/test/deploy-mocks.test.ts
@@ -1,0 +1,105 @@
+import { expect } from "chai";
+import { useEnvironment } from "./helpers";
+import { TASK_MANAGER_ADDRESS, TEST_BED_ADDRESS } from "../src/addresses";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+describe("Deploy Mocks Task", function () {
+  const getTestBedBytecode = async (hre: HardhatRuntimeEnvironment) => {
+    return await hre.ethers.provider.getCode(TEST_BED_ADDRESS);
+  };
+
+  describe("With logging enabled", function () {
+    useEnvironment("hardhat-logging-enabled");
+
+    it("should deploy mocks with logging and test bed", async function () {
+      await this.hre.run("deploy-mocks", {
+        deployTestBed: true,
+        logMocks: true,
+      });
+
+      // Verify contracts are deployed
+      const taskManager = await this.hre.ethers.getContractAt(
+        "TaskManager",
+        TASK_MANAGER_ADDRESS,
+      );
+      expect(await taskManager.exists()).to.equal(true);
+      expect(await taskManager.logOps()).to.equal(true);
+
+      // Verify test bed is deployed
+      const testBedBytecode = await getTestBedBytecode(this.hre);
+      expect(testBedBytecode.length).to.be.greaterThan(2);
+
+      const testBed = await this.hre.ethers.getContractAt(
+        "TestBed",
+        TEST_BED_ADDRESS,
+      );
+      expect(await testBed.exists()).to.equal(true);
+    });
+
+    it("should deploy mocks with logging but without test bed", async function () {
+      await this.hre.run("deploy-mocks", {
+        deployTestBed: false,
+        logMocks: true,
+      });
+
+      // Verify mock contracts are deployed
+      const taskManager = await this.hre.ethers.getContractAt(
+        "TaskManager",
+        TASK_MANAGER_ADDRESS,
+      );
+      expect(await taskManager.exists()).to.equal(true);
+      expect(await taskManager.logOps()).to.equal(true);
+
+      // Verify test bed is not deployed
+      const testBedBytecode = await getTestBedBytecode(this.hre);
+      expect(testBedBytecode).to.equal("0x");
+    });
+  });
+
+  describe("With logging disabled", function () {
+    useEnvironment("hardhat-logging-disabled");
+
+    it("should deploy mocks without logging and with test bed", async function () {
+      await this.hre.run("deploy-mocks", {
+        deployTestBed: true,
+        logMocks: false,
+      });
+
+      // Verify contracts are deployed
+      const taskManager = await this.hre.ethers.getContractAt(
+        "TaskManager",
+        TASK_MANAGER_ADDRESS,
+      );
+      expect(await taskManager.exists()).to.equal(true);
+      expect(await taskManager.logOps()).to.equal(false);
+
+      // Verify test bed is deployed
+      const testBedBytecode = await getTestBedBytecode(this.hre);
+      expect(testBedBytecode.length).to.be.greaterThan(2);
+
+      const testBed = await this.hre.ethers.getContractAt(
+        "TestBed",
+        TEST_BED_ADDRESS,
+      );
+      expect(await testBed.exists()).to.equal(true);
+    });
+
+    it("should deploy mocks without logging and without test bed", async function () {
+      await this.hre.run("deploy-mocks", {
+        deployTestBed: false,
+        logMocks: false,
+      });
+
+      // Verify mock contracts are deployed
+      const taskManager = await this.hre.ethers.getContractAt(
+        "TaskManager",
+        TASK_MANAGER_ADDRESS,
+      );
+      expect(await taskManager.exists()).to.equal(true);
+      expect(await taskManager.logOps()).to.equal(false);
+
+      // Verify test bed is not deployed
+      const testBedBytecode = await getTestBedBytecode(this.hre);
+      expect(testBedBytecode).to.equal("0x");
+    });
+  });
+});

--- a/test/fixture-projects/hardhat-logging-disabled/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-logging-disabled/hardhat.config.ts
@@ -1,0 +1,19 @@
+import { HardhatUserConfig } from "hardhat/types";
+import "@nomicfoundation/hardhat-ethers";
+import "@nomicfoundation/hardhat-chai-matchers";
+import "../../../src";
+
+const config: HardhatUserConfig = {
+  solidity: {
+    version: "0.8.25",
+    settings: {
+      evmVersion: "cancun",
+    },
+  },
+  defaultNetwork: "hardhat",
+  cofhe: {
+    logMocks: false,
+  },
+};
+
+export default config;

--- a/test/fixture-projects/hardhat-logging-enabled/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-logging-enabled/hardhat.config.ts
@@ -1,0 +1,19 @@
+import { HardhatUserConfig } from "hardhat/types";
+import "@nomicfoundation/hardhat-ethers";
+import "@nomicfoundation/hardhat-chai-matchers";
+import "../../../src";
+
+const config: HardhatUserConfig = {
+  solidity: {
+    version: "0.8.25",
+    settings: {
+      evmVersion: "cancun",
+    },
+  },
+  defaultNetwork: "hardhat",
+  cofhe: {
+    logMocks: true,
+  },
+};
+
+export default config;


### PR DESCRIPTION
Add configurable logging and test bed deployment to deploy-mocks task

Changes:
- Added logMocks config option under cofhe namespace in Hardhat config
- Added deployTestBed and logMocks parameters to deploy-mocks task
- Added tests to verify:
  - TaskManager's logOps setting based on logMocks parameter
  - TestBed deployment based on deployTestBed parameter

Testing:
- Added test cases for all combinations of logMocks and deployTestBed settings
- Tests verify both contract deployment and logging configuration
